### PR TITLE
remove context from API

### DIFF
--- a/cliware_test.go
+++ b/cliware_test.go
@@ -12,12 +12,12 @@ import (
 
 func TestRequestHandlerFunc(t *testing.T) {
 	var called bool
-	handlerFunc := func(ctx context.Context, req *http.Request) (resp *http.Response, err error) {
+	handlerFunc := func(req *http.Request) (resp *http.Response, err error) {
 		called = true
 		return nil, nil
 	}
 	var handler c.Handler = c.HandlerFunc(handlerFunc)
-	_, err := handler.Handle(nil, nil)
+	_, err := handler.Handle(nil)
 	if err != nil {
 		t.Error("Handle returned error: ", err)
 	}
@@ -93,7 +93,7 @@ func TestUseRequest(t *testing.T) {
 		return nil
 	})
 	handler, handlerCalled := createHandler()
-	_, err := chain.Exec(handler).Handle(nil, templateReq)
+	_, err := chain.Exec(handler).Handle(templateReq)
 	if err != nil {
 		t.Error("Handle returned error: ", err)
 	}
@@ -116,7 +116,7 @@ func TestUseResponse(t *testing.T) {
 		return nil
 	})
 	handler, handlerCalled := createHandler()
-	_, err := chain.Exec(handler).Handle(nil, nil)
+	_, err := chain.Exec(handler).Handle(nil)
 	if err != nil {
 		t.Error("Handle returned error: ", err)
 	}
@@ -133,7 +133,7 @@ func TestMiddlewareCalled(t *testing.T) {
 	m2, m2Called := createMiddleware()
 	handler, handlerCalled := createHandler()
 	chain := c.NewChain(m1, m2)
-	_, err := chain.Exec(handler).Handle(nil, nil)
+	_, err := chain.Exec(handler).Handle(nil)
 	if err != nil {
 		t.Error("Handle returned error: ", err)
 	}
@@ -155,7 +155,7 @@ func TestMiddlewareCalledWithParent(t *testing.T) {
 
 	chain := c.NewChain(m1)
 	childChain := chain.ChildChain(m2)
-	_, err := childChain.Exec(handler).Handle(nil, nil)
+	_, err := childChain.Exec(handler).Handle(nil)
 	if err != nil {
 		t.Error("Handle returned error: ", err)
 	}
@@ -186,7 +186,7 @@ func TestRequestProcessorNoError(t *testing.T) {
 	})
 	chain := c.NewChain(processor)
 	handler, handlerCalled := createHandler()
-	_, err := chain.Exec(handler).Handle(nil, nil)
+	_, err := chain.Exec(handler).Handle(nil)
 	if err != nil {
 		t.Error("Handle returned error: ", err)
 	}
@@ -207,7 +207,7 @@ func TestRequestProcessorWithError(t *testing.T) {
 	})
 	chain := c.NewChain(processor)
 	handler, handlerCalled := createHandler()
-	_, err := chain.Exec(handler).Handle(nil, nil)
+	_, err := chain.Exec(handler).Handle(nil)
 	if err != myErr {
 		t.Errorf("Expected error: \"%s\", got: \"%s\"", myErr, err)
 	}
@@ -227,7 +227,7 @@ func TestResponseProcessorNoError(t *testing.T) {
 	})
 	chain := c.NewChain(processor)
 	handler, handlerCalled := createHandler()
-	_, err := chain.Exec(handler).Handle(nil, nil)
+	_, err := chain.Exec(handler).Handle(nil)
 	if err != nil {
 		t.Error("Handle returned error: ", err)
 	}
@@ -248,7 +248,7 @@ func TestResponseProcessorWithError(t *testing.T) {
 	})
 	chain := c.NewChain(processor)
 	handler, handlerCalled := createHandler()
-	_, err := chain.Exec(handler).Handle(nil, nil)
+	_, err := chain.Exec(handler).Handle(nil)
 	if err != myErr {
 		t.Errorf("Expected error: \"%s\", got: \"%s\"", myErr, err)
 	}
@@ -268,7 +268,7 @@ func TestContextProcessor_Exec(t *testing.T) {
 	})
 	chain := c.NewChain(processor)
 	handler, handlerCalled := createHandler()
-	_, err := chain.Exec(handler).Handle(nil, nil)
+	_, err := chain.Exec(handler).Handle(c.EmptyRequest())
 	if err != nil {
 		t.Error("Handle returned error: ", err)
 	}
@@ -322,8 +322,8 @@ func createMiddleware() (middleware c.Middleware, called *bool) {
 	var middlewareCalled bool
 	middleware = c.MiddlewareFunc(func(next c.Handler) c.Handler {
 		middlewareCalled = true
-		return c.HandlerFunc(func(ctx context.Context, req *http.Request) (resp *http.Response, err error) {
-			return next.Handle(ctx, req)
+		return c.HandlerFunc(func(req *http.Request) (resp *http.Response, err error) {
+			return next.Handle(req)
 		})
 	})
 	return middleware, &middlewareCalled
@@ -331,7 +331,7 @@ func createMiddleware() (middleware c.Middleware, called *bool) {
 
 func createHandler() (handler c.Handler, called *bool) {
 	var handlerCalled bool
-	handler = c.HandlerFunc(func(ctx context.Context, req *http.Request) (resp *http.Response, err error) {
+	handler = c.HandlerFunc(func(req *http.Request) (resp *http.Response, err error) {
 		handlerCalled = true
 		return nil, nil
 	})

--- a/example_requestprocessor_test.go
+++ b/example_requestprocessor_test.go
@@ -1,7 +1,6 @@
 package cliware_test
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 
@@ -17,13 +16,13 @@ func basicAuth(username, password string) c.Middleware {
 	})
 }
 
-func nilHandler(ctx context.Context, req *http.Request) (*http.Response, error) {
+func nilHandler(req *http.Request) (*http.Response, error) {
 	return nil, nil
 }
 
 func ExampleRequestProcessor() {
 	req := c.EmptyRequest()
-	basicAuth("user", "pass").Exec(c.HandlerFunc(nilHandler)).Handle(nil, req)
+	basicAuth("user", "pass").Exec(c.HandlerFunc(nilHandler)).Handle(req)
 	username, password, ok := req.BasicAuth()
 	fmt.Println(ok)
 	fmt.Println(username)

--- a/example_responseprocessor_test.go
+++ b/example_responseprocessor_test.go
@@ -1,7 +1,6 @@
 package cliware_test
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 
@@ -47,7 +46,7 @@ func statusCodeToError() c.Middleware {
 
 // notFoundResponse is helper method that always returns HTTP response with
 // 404 Not Found status.
-func notFoundResponse(ctx context.Context, req *http.Request) (*http.Response, error) {
+func notFoundResponse(req *http.Request) (*http.Response, error) {
 	return &http.Response{
 		Status:     http.StatusText(http.StatusNotFound),
 		StatusCode: http.StatusNotFound,
@@ -61,6 +60,6 @@ func notFoundResponse(ctx context.Context, req *http.Request) (*http.Response, e
 }
 
 func ExampleResponseProcessor() {
-	_, err := statusCodeToError().Exec(c.HandlerFunc(notFoundResponse)).Handle(nil, nil)
+	_, err := statusCodeToError().Exec(c.HandlerFunc(notFoundResponse)).Handle(nil)
 	fmt.Println(err)
 }

--- a/example_test.go
+++ b/example_test.go
@@ -1,7 +1,6 @@
 package cliware_test
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"log"
@@ -83,12 +82,12 @@ func bodyToStdout() c.Middleware {
 // This is example of middleware without utility functions that does something
 // both before and after request has been sent.
 func trace(next c.Handler) c.Handler {
-	return c.HandlerFunc(func(ctx context.Context, req *http.Request) (resp *http.Response, err error) {
+	return c.HandlerFunc(func(req *http.Request) (resp *http.Response, err error) {
 		// do anything before request
 		fmt.Println("*** Before sending request.")
 
 		// call next middleware
-		resp, err = next.Handle(ctx, req)
+		resp, err = next.Handle(req)
 
 		// do anything after request
 		fmt.Println("*** After sending request.")
@@ -101,8 +100,7 @@ func trace(next c.Handler) c.Handler {
 // sender does actual request sending using htt.Client.
 // this is final handler that has to be called and it has to be passed to
 // chain Exec method.
-func sender(ctx context.Context, req *http.Request) (resp *http.Response, err error) {
-	req = req.WithContext(ctx)
+func sender(req *http.Request) (resp *http.Response, err error) {
 	return http.DefaultClient.Do(req)
 }
 
@@ -120,7 +118,7 @@ func Example() {
 	// other way to add middlewares is by using Use* method
 	chain.UseFunc(trace)
 	// execute chain and final middleware
-	chain.Exec(c.HandlerFunc(sender)).Handle(context.Background(), c.EmptyRequest())
+	chain.Exec(c.HandlerFunc(sender)).Handle(c.EmptyRequest())
 	// Output:
 	// *** Before sending request.
 	// User-Agent:  Cliware


### PR DESCRIPTION
Request already has context, so providing an additional context.Context is redundant.
This pull request contains breaking API changes.